### PR TITLE
chore: GH action to publish to NPM

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -30,4 +30,5 @@ jobs:
       set_version: ${{ github.event.inputs.set_version }}
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      npm_token: ${{ secrets.NPM_TOKEN }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -1,0 +1,23 @@
+name: Publish
+permissions:
+  checks: write
+  contents: write
+  pull-requests: write
+  statuses: write
+  id-token: write
+"on":
+  push:
+    branches:
+      - main
+    paths:
+      - .speakeasy/gen.lock
+  workflow_dispatch: {}
+jobs:
+  publish:
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
+    with:
+      target: '@quiverai/sdk'
+    secrets:
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      npm_token: ${{ secrets.NPM_TOKEN }}
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -8,3 +8,6 @@ targets:
         target: typescript
         source: OpenAPI
         output: .
+        publish:
+            npm:
+                token: $npm_token


### PR DESCRIPTION
## Adds GH Action for publishing SDK to NPM

***Generated using:***

```bash
speakeasy configure publishing
```

> [!NOTE]
> Before merging, make sure:
> 
> - `NPM_TOKEN` is configured as a secret
> - The [Speakeasy Github App](https://github.com/apps/speakeasy-github) is installed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces automated publishing of the SDK to NPM and ensures required tokens are passed through CI.
> 
> - Adds `sdk_publish.yaml` workflow to publish `@quiverai/sdk` on pushes to `main` when `.speakeasy/gen.lock` changes (and via manual dispatch), using Speakeasy publish action with `GITHUB_TOKEN`, `NPM_TOKEN`, and `SPEAKEASY_API_KEY`.
> - Updates `sdk_generation.yaml` to include `npm_token` secret for generation jobs.
> - Updates `.speakeasy/workflow.yaml` to configure `publish.npm.token` via `$npm_token`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81cae1d8a9c93a0fc3be7233259c101de18685e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->