### PR TITLE
chore(sdk): apply SVG stream compatibility overlay

### DIFF
--- a/.speakeasy/svg-stream-forward-compat.overlay.yaml
+++ b/.speakeasy/svg-stream-forward-compat.overlay.yaml
@@ -1,0 +1,9 @@
+overlay: 1.0.0
+info:
+  title: Keep SVG event streams forward compatible
+  version: 1.0.0
+actions:
+  - target: $.components.schemas.SvgStreamEvent
+    description: Allow generated SDKs to preserve unknown future SSE event variants.
+    update:
+      x-speakeasy-unknown-values: allow

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -4,6 +4,8 @@ sources:
     OpenAPI:
         inputs:
             - location: https://api.quiver.ai/v1/openapi.json
+        overlays:
+            - location: ./.speakeasy/svg-stream-forward-compat.overlay.yaml
         registry:
             location: registry.speakeasyapi.dev/quiverai/clients/open-api
 targets:


### PR DESCRIPTION
## Summary

- Add a Speakeasy OpenAPI Overlay for the outer `SvgStreamEvent` discriminated union.
- Configure autonomous SDK generation to apply the overlay on every run.
- Preserve unknown future SVG SSE variants as typed `UNKNOWN` events instead of aborting the stream.
- Leave all generated SDK source unchanged.

Linear: [ENG-1946](https://linear.app/quiverai/issue/ENG-1946/complete-public-svg-sse-metadata-contract-and-generated-sdk)
Producer repair: [quiverai/arrow#798](https://github.com/quiverai/arrow/pull/798)
Deferred public metadata follow-up: [quiverai/quiverai-monorepo#1785](https://github.com/quiverai/quiverai-monorepo/pull/1785)
Emergency boundary workaround: [quiverai/quiverai-monorepo#1772](https://github.com/quiverai/quiverai-monorepo/pull/1772)

## Verification

- `speakeasy overlay validate -o .speakeasy/svg-stream-forward-compat.overlay.yaml`
- Speakeasy 1.790.3 generated from the public OpenAPI with this workflow overlay; OpenAPI validation, SDK lint, and SDK build passed
- Generated content models can expose `sRef?: string | null` and `styleCreated?: boolean | null` once those fields are released in the public contract
- Generate and vectorize HTTP/SSE fixtures: `generating → unknown style → content → [DONE]` produced `generating → UNKNOWN → content`; the raw unknown frame and later content remained available
- `git diff --check`

## Compatibility note

The Speakeasy open-union runtime also maps malformed known variants to `UNKNOWN`. Valid known variants remain strongly typed.

## Agent assistance

Sponsor: @xn1cklas

Assistance:

- Codex:gpt-5 — session `openai:019f8e8e-1849-7772-8b12-4a0ea878a0b9` — overlay design, disposable generation proof, configuration change, and review

Final reviewed head: `59f917c`
